### PR TITLE
feat: add created argument to Repository.get_workflow_runs()

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -3161,6 +3161,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         branch=github.GithubObject.NotSet,
         event=github.GithubObject.NotSet,
         status=github.GithubObject.NotSet,
+        created=github.GithubObject.NotSet
     ):
         """
         :calls: `GET /repos/{owner}/{repo}/actions/runs <https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository>`_
@@ -3168,6 +3169,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         :param branch: :class:`github.Branch.Branch` or string
         :param event: string
         :param status: string `queued`, `in_progress`, `completed`, `success`, `failure`, `neutral`, `cancelled`, `skipped`, `timed_out`, or `action_required`
+        :param created: string
 
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.WorkflowRun.WorkflowRun`
         """
@@ -3199,6 +3201,9 @@ class Repository(github.GithubObject.CompletableGithubObject):
             url_parameters["event"] = event
         if status is not github.GithubObject.NotSet:
             url_parameters["status"] = status
+
+        if created is not github.GithubObject.NotSet:
+            url_parameters["created"] = created
 
         return github.PaginatedList.PaginatedList(
             github.WorkflowRun.WorkflowRun,


### PR DESCRIPTION
We want to use the `created` query parameter available in [Github's workflow runs endpoint](https://docs.github.com/en/rest/reference/actions#list-workflow-runs), which is not provided by the Python package.